### PR TITLE
Fix/wms reprojection

### DIFF
--- a/app/wms/src/main/java/org/orbisgis/server/wms/GetMapHandler.java
+++ b/app/wms/src/main/java/org/orbisgis/server/wms/GetMapHandler.java
@@ -36,31 +36,14 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
-
-import com.vividsolutions.jts.geom.Geometry;
 import net.opengis.wms.Layer;
 import org.gdms.data.DataSource;
 import org.gdms.data.DataSourceFactory;
-import org.gdms.data.NoSuchTableException;
-import org.gdms.data.crs.SpatialReferenceSystem;
-import org.gdms.data.file.FileSourceDefinition;
-import org.gdms.data.schema.DefaultMetadata;
-import org.gdms.data.schema.Metadata;
 import org.gdms.data.schema.MetadataUtilities;
-import org.gdms.data.types.Type;
-import org.gdms.data.types.TypeFactory;
 import org.gdms.data.values.Value;
 import org.gdms.data.values.ValueFactory;
-import org.gdms.driver.DataSet;
 import org.gdms.driver.DiskBufferDriver;
-import org.gdms.driver.DriverException;
-import org.gdms.driver.driverManager.DriverManager;
-import org.gdms.source.SourceManager;
-import org.gdms.sql.engine.Engine;
-import org.gdms.sql.engine.SQLStatement;
 import org.gdms.sql.function.spatial.geometry.crs.ST_Transform;
 import org.orbisgis.core.DataManager;
 import org.orbisgis.core.Services;
@@ -72,7 +55,6 @@ import org.orbisgis.core.renderer.ImageRenderer;
 import org.orbisgis.core.renderer.Renderer;
 import org.orbisgis.core.renderer.se.SeExceptions;
 import org.orbisgis.core.renderer.se.Style;
-import org.orbisgis.core.renderer.se.parameter.color.ColorHelper;
 import org.orbisgis.progress.NullProgressMonitor;
 
 /**
@@ -267,14 +249,12 @@ public final class GetMapHandler {
                         Graphics2D g2 = img.createGraphics();
 
                         Color color;
-                        if (transparent) {
-                                color = ColorHelper.getColorWithAlpha(Color.decode(bgColor), 0.0);
-                        } else {
+                        if (!transparent) {
                                 color = Color.decode(bgColor);
+                                g2.setBackground(color);
+                                g2.clearRect(0, 0, width, height);
                         }
 
-                        g2.setBackground(color);
-                        g2.clearRect(0, 0, width, height);
 
                         NullProgressMonitor pm = new NullProgressMonitor();
                         renderer.draw(mt, g2, width, height, layers, pm);
@@ -374,7 +354,7 @@ public final class GetMapHandler {
                 }
 
                 if (queryParameters.containsKey("TRANSPARENT")) {
-                        transparent = Boolean.getBoolean(queryParameters.get("TRANSPARENT")[0]);
+                        transparent = Boolean.valueOf(queryParameters.get("TRANSPARENT")[0]);
                 }
 
                 if (queryParameters.containsKey("BGCOLOR")) {

--- a/app/wms/src/test/java/org/orbisgis/server/wms/WMSTest.java
+++ b/app/wms/src/test/java/org/orbisgis/server/wms/WMSTest.java
@@ -27,8 +27,11 @@
  */
 package org.orbisgis.server.wms;
 
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,11 +46,13 @@ import org.gdms.data.NoSuchTableException;
 import org.gdms.data.schema.MetadataUtilities;
 import org.gdms.data.values.Value;
 import org.gdms.data.values.ValueFactory;
+import org.gdms.geometryUtils.GeometryTypeUtil;
 import org.gdms.source.SourceManager;
 import org.gdms.sql.function.spatial.geometry.crs.ST_Transform;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.orbisgis.core.DataManager;
 import org.orbisgis.core.Services;
 import org.orbisgis.core.renderer.se.Style;
@@ -118,11 +123,12 @@ public class WMSTest {
             h.put("LAYERS", new String[]{"cantons"});
             h.put("STYLES", new String[]{""});
             h.put("CRS", new String[]{toCRS});
-            h.put("BBOX", new String[]{"2677441.0", "1197822.0", "1620431.0", "47680.0"});
+            h.put("BBOX", new String[]{"-5.372757617915", "9.326100042301633", "41.3630420705024", "51.089386147807105"});
             h.put("WIDTH", new String[]{"874"});
             h.put("HEIGHT", new String[]{"593"});
             h.put("FORMAT", new String[]{"image/png"});
             h.put("VERSION", new String[]{"1.3.0"});
+            h.put("TRANSPARENT", new String[]{"TRUE"});
             // Get the original source
             DataSource source = wms.getContext().getDataManager().getDataSource("cantons");
             source.open();
@@ -133,10 +139,8 @@ public class WMSTest {
             } finally {
                 source.close();
             }
-
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            wms.processRequests(h, out, r);
-
+            FileOutputStream fileOutputStream = new FileOutputStream(new File("target/testReprojection.png"));
+            wms.processRequests(h, fileOutputStream, r);
             // Get the projection source name
             String sourceName = GetMapHandler.getProjectionSourceName("cantons",toCRS);
             DataSource projSource = wms.getContext().getDataManager().getDataSource(sourceName);


### PR DESCRIPTION
About #26
- Do not use SQL function anymore, the new source (projected one) gather also other fields in order to manage value based legend.
- In the past, each call of getMap with another projection create a new datasource, I remove the deletion of new data source. May be we have to enhance this thing later.
- Add a unit test for projection
